### PR TITLE
fix: user undefined crash board

### DIFF
--- a/back/src/events/broadcast.events.ts
+++ b/back/src/events/broadcast.events.ts
@@ -34,7 +34,12 @@ export default function (io: Server, {userRepo, boardRepo}: Components) {
                     components: savedBoard.components,
                 }
                 for (const uuid of savedBoard.users) {
-                    board.users.push(await userRepo.findById(uuid))
+                    try {
+                        board.users.push(await userRepo.findById(uuid))
+                    } catch (e) {
+                        console.log('user %s not found', uuid)
+                    }
+
                 }
 
                 console.log("broadcast board : ", boardId);


### PR DESCRIPTION
found a issue, when refreshing windows, sometimes it adds a user 'undefined' (didn't find when yet). then the emit board crash when user undefined